### PR TITLE
Updating code to new 3.3 namespaces

### DIFF
--- a/src/Routing/Filter/NameTransactionFilter.php
+++ b/src/Routing/Filter/NameTransactionFilter.php
@@ -9,7 +9,7 @@ namespace NewRelic\Routing\Filter;
 
 use Cake\Event\Event;
 use Cake\Routing\DispatcherFilter;
-use Cake\Network\Http\Request;
+use Cake\Network\Request;
 use Cake\Utility\Inflector;
 
 /**
@@ -41,7 +41,7 @@ class NameTransactionFilter extends DispatcherFilter
      *
      * Name the transaction using request data.
      *
-     * @param Cake\Network\Http\Network $request The request.
+     * @param Cake\Network\Network $request The request.
      * @return string
      */
     public function nameTransaction(Request $request)

--- a/tests/TestCase/Routing/Filter/NameTransactionFilterTest.php
+++ b/tests/TestCase/Routing/Filter/NameTransactionFilterTest.php
@@ -9,7 +9,7 @@ namespace NewRelic\Test\Routing\Filter;
 
 use NewRelic\Routing\Filter\NameTransactionFilter;
 use Cake\Routing\DispatcherFilter;
-use Cake\Network\Http\Request;
+use Cake\Network\Request;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -29,7 +29,7 @@ class NameTransactionsFilterTest extends TestCase
     /**
      * A test request.
      *
-     * @var Cake\Network\Http\Request
+     * @var Cake\Network\Request
      */
     public $Request;
 


### PR DESCRIPTION
3.3 has removed Network/HTTP namespace as of 3.3 - this is now just Network/Request
