### PR TITLE
Add instructions to use the NameTransactionMiddleware()

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,20 @@ file is located.)
 
 ### Enable name transaction
 
+#### Using Dispatcher
+
 Add the Dispatcher Filter to the `bootstrap.php` file:
 
     // New Relic name transaction dispatcher filter
     DispatcherFactory::add('NewRelic.NameTransaction');
+
+#### Using Middleware
+
+Add the Middleware to the `src/Application.php` file after the `RoutingMiddleware`:
+
+    $middlewareQueue
+        ->add(new RoutingMiddleware($this))
+        ->add(new NameTransactionMiddleware());
 
 ### Enable browser timing
 


### PR DESCRIPTION
I think it's important mention that `NameTransactionMiddleware()` needs to be added after `RoutingMiddleware()` otherwise `$request->params` will be an empty array.